### PR TITLE
feat: Remove cli-highlight package

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -129,9 +129,7 @@ export class MyCustomLogger extends AbstractLogger {
         logMessage: LogMessage | LogMessage[],
         queryRunner?: QueryRunner,
     ) {
-        const messages = this.prepareLogMessages(logMessage, {
-            highlightSql: false,
-        })
+        const messages = this.prepareLogMessages(logMessage, {})
 
         for (let message of messages) {
             switch (message.type ?? level) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
         "chalk": "^4.1.2",
-        "cli-highlight": "^2.1.11",
         "date-fns": "^2.29.3",
         "debug": "^4.3.4",
         "dotenv": "^16.0.3",
@@ -1625,11 +1624,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
-    },
     "node_modules/anymatch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
@@ -2697,61 +2691,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/cli-highlight": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
-      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "highlight.js": "^10.7.1",
-        "mz": "^2.4.0",
-        "parse5": "^5.1.1",
-        "parse5-htmlparser2-tree-adapter": "^6.0.0",
-        "yargs": "^16.0.0"
-      },
-      "bin": {
-        "highlight": "bin/highlight"
-      },
-      "engines": {
-        "node": ">=8.0.0",
-        "npm": ">=5.0.0"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/cliui": {
@@ -6390,14 +6329,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -9081,16 +9012,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
-    },
     "node_modules/named-placeholders": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
@@ -9658,6 +9579,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9971,24 +9893,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/parse5": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
-      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
-      "dependencies": {
-        "parse5": "^6.0.1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "node_modules/pascalcase": {
       "version": "0.1.1",
@@ -12431,25 +12335,6 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/through": {

--- a/package.json
+++ b/package.json
@@ -219,7 +219,6 @@
     "app-root-path": "^3.1.0",
     "buffer": "^6.0.3",
     "chalk": "^4.1.2",
-    "cli-highlight": "^2.1.11",
     "date-fns": "^2.29.3",
     "debug": "^4.3.4",
     "dotenv": "^16.0.3",

--- a/src/commands/QueryCommand.ts
+++ b/src/commands/QueryCommand.ts
@@ -48,8 +48,7 @@ export class QueryCommand implements yargs.CommandModule {
             queryRunner = dataSource.createQueryRunner()
             const query = args.query as string
             console.log(
-                chalk.green("Running query: ") +
-                    PlatformTools.highlightSql(query),
+                chalk.green("Running query: ") + query,
             )
             const queryResult = await queryRunner.query(query)
 
@@ -61,11 +60,7 @@ export class QueryCommand implements yargs.CommandModule {
                 )
             } else {
                 console.log(chalk.green("Query has been executed. Result: "))
-                console.log(
-                    PlatformTools.highlightJson(
-                        JSON.stringify(queryResult, undefined, 2),
-                    ),
-                )
+                console.log(JSON.stringify(queryResult, undefined, 2))
             }
 
             await queryRunner.release()

--- a/src/commands/SchemaLogCommand.ts
+++ b/src/commands/SchemaLogCommand.ts
@@ -1,5 +1,4 @@
 import { DataSource } from "../data-source/DataSource"
-import { highlight } from "cli-highlight"
 import * as yargs from "yargs"
 import chalk from "chalk"
 import { PlatformTools } from "../platform/PlatformTools"
@@ -81,7 +80,7 @@ export class SchemaLogCommand implements yargs.CommandModule {
                         sqlString.substr(-1) === ";"
                             ? sqlString
                             : sqlString + ";"
-                    console.log(highlight(sqlString))
+                    console.log((sqlString))
                 })
             }
             await dataSource.destroy()

--- a/src/logger/AbstractLogger.ts
+++ b/src/logger/AbstractLogger.ts
@@ -298,7 +298,6 @@ export abstract class AbstractLogger implements Logger {
             ...{
                 addColonToPrefix: true,
                 appendParameterAsComment: true,
-                highlightSql: true,
             },
             ...options,
         }
@@ -322,10 +321,6 @@ export abstract class AbstractLogger implements Logger {
                     sql += ` -- PARAMETERS: ${this.stringifyParams(
                         message.parameters,
                     )}`
-                }
-
-                if (options.highlightSql) {
-                    sql = PlatformTools.highlightSql(sql)
                 }
 
                 message.message = sql

--- a/src/logger/FileLogger.ts
+++ b/src/logger/FileLogger.ts
@@ -34,7 +34,6 @@ export class FileLogger extends AbstractLogger {
         queryRunner?: QueryRunner,
     ) {
         const messages = this.prepareLogMessages(logMessage, {
-            highlightSql: false,
             addColonToPrefix: false,
         })
 

--- a/src/logger/Logger.ts
+++ b/src/logger/Logger.ts
@@ -97,7 +97,6 @@ export type LogMessageType =
  * Options for prepare log messages
  */
 export type PrepareLogMessagesOptions = {
-    highlightSql: boolean
     appendParameterAsComment: boolean
     addColonToPrefix: boolean
 }

--- a/src/logger/SimpleConsoleLogger.ts
+++ b/src/logger/SimpleConsoleLogger.ts
@@ -15,9 +15,7 @@ export class SimpleConsoleLogger extends AbstractLogger {
         logMessage: LogMessage | LogMessage[],
         queryRunner?: QueryRunner,
     ) {
-        const messages = this.prepareLogMessages(logMessage, {
-            highlightSql: false,
-        })
+        const messages = this.prepareLogMessages(logMessage, {})
 
         for (let message of messages) {
             switch (message.type ?? level) {

--- a/src/platform/BrowserPlatformTools.template
+++ b/src/platform/BrowserPlatformTools.template
@@ -107,20 +107,6 @@ export class PlatformTools {
     }
 
     /**
-     * Highlights sql string to be print in the console.
-     */
-    static highlightSql(sql: string) {
-        return sql;
-    }
-
-    /**
-     * Highlights json string to be print in the console.
-     */
-    static highlightJson(json: string) {
-        return json;
-    }
-
-    /**
      * Logging functions needed by AdvancedConsoleLogger (but here without chalk)
      */
     static logInfo(prefix: string, info: any) {

--- a/src/platform/PlatformTools.ts
+++ b/src/platform/PlatformTools.ts
@@ -2,7 +2,6 @@ import * as path from "path"
 import * as fs from "fs"
 import dotenv from "dotenv"
 import chalk from "chalk"
-import { highlight, Theme } from "cli-highlight"
 
 export { ReadStream } from "fs"
 export { EventEmitter } from "events"
@@ -201,28 +200,6 @@ export class PlatformTools {
      */
     static getEnvVariable(name: string): any {
         return process.env[name]
-    }
-
-    /**
-     * Highlights sql string to be print in the console.
-     */
-    static highlightSql(sql: string) {
-        const theme: Theme = {
-            keyword: chalk.blueBright,
-            literal: chalk.blueBright,
-            string: chalk.white,
-            type: chalk.magentaBright,
-            built_in: chalk.magentaBright,
-            comment: chalk.gray,
-        }
-        return highlight(sql, { theme: theme, language: "sql" })
-    }
-
-    /**
-     * Highlights json string to be print in the console.
-     */
-    static highlightJson(json: string) {
-        return highlight(json, { language: "json" })
     }
 
     /**


### PR DESCRIPTION
While cli highlighting can be a very useful tool, the package `cli-highlight` has a handful of issues for us:
1. The library seems abandoned, and a potential security issue waiting to happen.
2. When loading typeorm, over 30% of the code loaded into memory is coming from `cli-highlight` and its dependencies.