### PR TITLE
feat: Disable logging of query parameters by default

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -129,7 +129,7 @@ export class MyCustomLogger extends AbstractLogger {
         logMessage: LogMessage | LogMessage[],
         queryRunner?: QueryRunner,
     ) {
-        const messages = this.prepareLogMessages(logMessage, {})
+        const messages = this.prepareLogMessages(logMessage)
 
         for (let message of messages) {
             switch (message.type ?? level) {

--- a/src/logger/AbstractLogger.ts
+++ b/src/logger/AbstractLogger.ts
@@ -7,7 +7,6 @@ import {
 } from "./Logger"
 import { QueryRunner } from "../query-runner/QueryRunner"
 import { LoggerOptions } from "./LoggerOptions"
-import { PlatformTools } from "../platform/PlatformTools"
 
 export abstract class AbstractLogger implements Logger {
     // -------------------------------------------------------------------------
@@ -295,10 +294,8 @@ export abstract class AbstractLogger implements Logger {
         options?: Partial<PrepareLogMessagesOptions>,
     ): LogMessage[] {
         options = {
-            ...{
-                addColonToPrefix: true,
-                appendParameterAsComment: true,
-            },
+            addColonToPrefix: true,
+            appendParameterAsComment: false,
             ...options,
         }
         const messages = Array.isArray(logMessage) ? logMessage : [logMessage]

--- a/src/logger/AdvancedConsoleLogger.ts
+++ b/src/logger/AdvancedConsoleLogger.ts
@@ -16,7 +16,7 @@ export class AdvancedConsoleLogger extends AbstractLogger {
         logMessage: LogMessage | LogMessage[],
         queryRunner?: QueryRunner,
     ) {
-        const messages = this.prepareLogMessages(logMessage)
+        const messages = this.prepareLogMessages(logMessage, { appendParameterAsComment: true })
 
         for (let message of messages) {
             switch (message.type ?? level) {

--- a/src/logger/DebugLogger.ts
+++ b/src/logger/DebugLogger.ts
@@ -65,9 +65,7 @@ export class DebugLogger extends AbstractLogger {
         logMessage: LogMessage | LogMessage[],
         queryRunner?: QueryRunner,
     ) {
-        const messages = this.prepareLogMessages(logMessage, {
-            appendParameterAsComment: false,
-        })
+        const messages = this.prepareLogMessages(logMessage)
 
         for (let message of messages) {
             const messageTypeOrLevel = message.type ?? level

--- a/src/logger/SimpleConsoleLogger.ts
+++ b/src/logger/SimpleConsoleLogger.ts
@@ -15,7 +15,7 @@ export class SimpleConsoleLogger extends AbstractLogger {
         logMessage: LogMessage | LogMessage[],
         queryRunner?: QueryRunner,
     ) {
-        const messages = this.prepareLogMessages(logMessage, {})
+        const messages = this.prepareLogMessages(logMessage)
 
         for (let message of messages) {
             switch (message.type ?? level) {


### PR DESCRIPTION
Query parameters can often contain confidential data, and logging them to console shouldn't be enabled by default.