### PR TITLE
fix: Use BEGIN IMMEDIATE with pooled sqlite driver

### DIFF
--- a/src/driver/sqlite-pooled/SqlitePooledQueryRunner.ts
+++ b/src/driver/sqlite-pooled/SqlitePooledQueryRunner.ts
@@ -137,7 +137,7 @@ export class SqlitePooledQueryRunner extends AbstractSqliteQueryRunner {
             }
         }
 
-        await this.query("BEGIN TRANSACTION")
+        await this.query("BEGIN IMMEDIATE TRANSACTION")
 
         await this.broadcaster.broadcast("AfterTransactionStart")
     }

--- a/test/functional/transaction/sqlite-pooled-transaction-type/sqlite-pooled-transaction-type.ts
+++ b/test/functional/transaction/sqlite-pooled-transaction-type/sqlite-pooled-transaction-type.ts
@@ -29,7 +29,6 @@ describe("transaction > transaction with sqlite-pooled", () => {
                 await queryRunner.startTransaction()
 
                 expect(queryFn.called).to.be.true
-                console.log(queryFn.firstCall.args[0])
                 expect(queryFn.firstCall.args[0]).to.be.eql(
                     "BEGIN IMMEDIATE TRANSACTION",
                 )

--- a/test/functional/transaction/sqlite-pooled-transaction-type/sqlite-pooled-transaction-type.ts
+++ b/test/functional/transaction/sqlite-pooled-transaction-type/sqlite-pooled-transaction-type.ts
@@ -1,0 +1,41 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import sinon from "sinon"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../utils/test-utils"
+import { DataSource } from "../../../../src/data-source/DataSource"
+
+describe("transaction > transaction with sqlite-pooled", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                enabledDrivers: ["sqlite-pooled"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should use BEGIN IMMEDIATE to start a trx", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const queryRunner = connection.createQueryRunner()
+
+                const queryFn = sinon.spy(queryRunner, "query")
+                await queryRunner.startTransaction()
+
+                expect(queryFn.called).to.be.true
+                console.log(queryFn.firstCall.args[0])
+                expect(queryFn.firstCall.args[0]).to.be.eql(
+                    "BEGIN IMMEDIATE TRANSACTION",
+                )
+
+                await queryRunner.commitTransaction()
+                await queryRunner.release()
+            }),
+        ))
+})


### PR DESCRIPTION
### Description of change

Use `BEGIN IMMEDIATE` when opening transaction with pooled sqlite driver. If we don't lock the DB immediately, it's possible to suffer from DB locked errors in the middle of a transaction, which could require retrying the entire transaction. It's better to handle these in the beginning of a trx and do the retry there.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
