### PR TITLE
Fix sqlite pooled write connection mutex not being released in case of an error

### DIFF
--- a/src/driver/sqlite-pooled/LeasedDbConnection.ts
+++ b/src/driver/sqlite-pooled/LeasedDbConnection.ts
@@ -9,6 +9,11 @@ import { DbLease, DbLeaseHolder, DbLeaseOwner } from "./SqlitePooledTypes"
  */
 export class LeasedDbConnection implements DbLease {
     private isReleased = false
+    private _isInvalid = false
+
+    public get isInvalid() {
+        return this._isInvalid
+    }
 
     public get connection(): Sqlite3Database {
         if (this.isReleased) {
@@ -25,7 +30,7 @@ export class LeasedDbConnection implements DbLease {
     ) {}
 
     public markAsInvalid() {
-        this.leaseOwner.invalidateConnection(this)
+        this._isInvalid = true
     }
 
     async release() {

--- a/src/driver/sqlite-pooled/SqlitePooledTypes.ts
+++ b/src/driver/sqlite-pooled/SqlitePooledTypes.ts
@@ -13,7 +13,6 @@ export interface SqliteConnectionPool {
     ): Promise<T>
     leaseConnection(dbLeaseHolder: DbLeaseHolder): Promise<DbLease>
     releaseConnection(leasedDbConnection: DbLease): void
-    invalidateConnection(leasedDbConnection: DbLease): void
     close(): Promise<void>
 }
 
@@ -24,6 +23,7 @@ export interface SqliteConnectionPool {
  */
 export interface DbLease {
     readonly connection: Sqlite3Database
+    readonly isInvalid: boolean
 
     /**
      * Marks the connection as invalid. This will cause the
@@ -42,7 +42,6 @@ export interface DbLease {
 }
 
 export interface DbLeaseOwner {
-    invalidateConnection(leasedDbConnection: DbLease): void
     releaseConnection(leasedDbConnection: DbLease): void
 }
 

--- a/src/driver/sqlite-pooled/SqliteReadWriteQueryRunner.ts
+++ b/src/driver/sqlite-pooled/SqliteReadWriteQueryRunner.ts
@@ -131,8 +131,8 @@ export class SqliteReadWriteQueryRunner
 
             await this.broadcaster.broadcast("AfterTransactionCommit")
         } catch (commitError) {
-            this.trxDbLease.markAsInvalid()
             captureException(new TransactionCommitFailedError(commitError))
+            this.trxDbLease.markAsInvalid()
             throw commitError
         } finally {
             this.releaseTrxDbLease()
@@ -157,8 +157,8 @@ export class SqliteReadWriteQueryRunner
 
             await this.broadcaster.broadcast("AfterTransactionRollback")
         } catch (rollbackError) {
-            this.trxDbLease.markAsInvalid()
             captureException(new TransactionRollbackFailedError(rollbackError))
+            this.trxDbLease.markAsInvalid()
             throw rollbackError
         } finally {
             this.releaseTrxDbLease()

--- a/src/driver/sqlite-pooled/SqliteReadonlyConnectionPool.ts
+++ b/src/driver/sqlite-pooled/SqliteReadonlyConnectionPool.ts
@@ -89,11 +89,10 @@ export class SqliteReadonlyConnectionPool implements SqliteConnectionPool {
         return new LeasedDbConnection(dbConnection, this, dbLeaseHolder)
     }
 
-    public invalidateConnection(leasedDbConnection: DbLease) {
-        this.invalidConnections.add(leasedDbConnection.connection)
-    }
-
     public releaseConnection(leasedDbConnection: DbLease) {
+        if (leasedDbConnection.isInvalid) {
+            this.invalidConnections.add(leasedDbConnection.connection)
+        }
         this.dbLeases.delete(leasedDbConnection)
         this.pool.release(leasedDbConnection.connection)
     }

--- a/src/driver/sqlite-pooled/SqliteWriteConnection.ts
+++ b/src/driver/sqlite-pooled/SqliteWriteConnection.ts
@@ -36,7 +36,7 @@ export class SqliteWriteConnection
     private dbLease: DbLease | undefined
 
     constructor(
-        private readonly sqliteLibray: SqliteLibrary,
+        private readonly sqliteLibrary: SqliteLibrary,
         private readonly options: {
             acquireTimeout: number
             destroyTimeout: number
@@ -77,7 +77,7 @@ export class SqliteWriteConnection
 
         if (this.writeConnectionPromise) {
             const dbConnection = await this.writeConnectionPromise
-            this.sqliteLibray.destroyDatabaseConnection(dbConnection)
+            this.sqliteLibrary.destroyDatabaseConnection(dbConnection)
         }
     }
 
@@ -135,7 +135,7 @@ export class SqliteWriteConnection
         try {
             const connection = await this.writeConnectionPromise
             if (!this.isConnectionValid) {
-                this.sqliteLibray.destroyDatabaseConnection(connection)
+                this.sqliteLibrary.destroyDatabaseConnection(connection)
                 this.writeConnectionPromise = null
             }
         } finally {
@@ -149,7 +149,7 @@ export class SqliteWriteConnection
     ): Promise<LeasedDbConnection> {
         if (!this.writeConnectionPromise) {
             this.writeConnectionPromise =
-                this.sqliteLibray.createDatabaseConnection()
+                this.sqliteLibrary.createDatabaseConnection()
         }
 
         const dbConnection = await this.writeConnectionPromise
@@ -166,7 +166,7 @@ export class SqliteWriteConnection
         }
 
         this.writeConnectionPromise =
-            this.sqliteLibray.createDatabaseConnection()
+            this.sqliteLibrary.createDatabaseConnection()
         return this.writeConnectionPromise
     }
 

--- a/src/driver/sqlite-pooled/SqliteWriteConnection.ts
+++ b/src/driver/sqlite-pooled/SqliteWriteConnection.ts
@@ -12,6 +12,8 @@ import { DriverAlreadyReleasedError } from "../../error/DriverAlreadyReleasedErr
 import { SqliteLibrary } from "./SqliteLibrary"
 import { LeasedDbConnection } from "./LeasedDbConnection"
 import { TimeoutTimer } from "./Timer"
+import { InvariantViolatedError } from "../../error/InvariantViolatedError"
+import { LockAcquireTimeoutError } from "../../error/LockAcquireTimeoutError"
 
 /**
  * A single write connection to the database.
@@ -20,11 +22,6 @@ export class SqliteWriteConnection
     implements SqliteConnectionPool, DbLeaseOwner
 {
     private writeConnectionPromise: Promise<Sqlite3Database> | null = null
-
-    /**
-     * Should the connection be re-created after it has been released
-     */
-    private isConnectionValid = true
 
     private isReleased = false
 
@@ -91,18 +88,29 @@ export class SqliteWriteConnection
             return await this.writeConnectionMutex.runExclusive(async () => {
                 this.dbLease = await this.createAndGetConnection(dbLeaseHolder)
 
-                const result = await callback(this.dbLease)
+                const result = await callback(this.dbLease).finally(() => {
+                    // runExclusive will make sure the mutex is released. Make
+                    // sure we also mark the lease as released
+                    const dbLease = this.dbLease
+                    this.dbLease = undefined
+
+                    if (dbLease && dbLease.isInvalid) {
+                        this.sqliteLibrary.destroyDatabaseConnection(
+                            dbLease.connection,
+                        )
+                        this.writeConnectionPromise = null
+                    }
+                })
 
                 return result
             })
         } catch (error) {
             if (error === E_TIMEOUT) {
                 captureException(error)
+                this.throwLockTimeoutError(error)
             }
 
             throw error
-        } finally {
-            this.dbLease = undefined
         }
     }
 
@@ -113,6 +121,10 @@ export class SqliteWriteConnection
             await this.writeConnectionMutex.acquire()
         } catch (error) {
             captureException(error)
+
+            if (error === E_TIMEOUT) {
+                this.throwLockTimeoutError(error)
+            }
             throw error
         }
 
@@ -120,21 +132,26 @@ export class SqliteWriteConnection
         return this.dbLease
     }
 
-    public invalidateConnection(leasedDbConnection: DbLease): void {
-        assert(this.dbLease === leasedDbConnection)
-        assert(this.writeConnectionMutex.isLocked())
-        assert(this.writeConnectionPromise)
-        this.isConnectionValid = false
-    }
-
     public async releaseConnection(leasedDbConnection: DbLease) {
-        assert(this.dbLease === leasedDbConnection)
-        assert(this.writeConnectionMutex.isLocked())
-        assert(this.writeConnectionPromise)
+        if (leasedDbConnection !== this.dbLease) {
+            // Someone is trying to release a connection that is no longer be
+            // the active connection. This is most likely a bug somewhere. In
+            // this case we can't release it, since it might have been already
+            // acquired by someone else. The best we can do is capture the
+            // exception and hope for the best.
+            this.captureInvariantViolated({
+                method: "releaseConnection",
+                givenConnectionMatches: this.dbLease === leasedDbConnection,
+                mutexIsLocked: this.writeConnectionMutex.isLocked(),
+                hasWriteConnection: !!this.writeConnectionPromise,
+            })
+            return
+        }
 
         try {
+            assert(this.writeConnectionPromise)
             const connection = await this.writeConnectionPromise
-            if (!this.isConnectionValid) {
+            if (leasedDbConnection.isInvalid) {
                 this.sqliteLibrary.destroyDatabaseConnection(connection)
                 this.writeConnectionPromise = null
             }
@@ -174,5 +191,23 @@ export class SqliteWriteConnection
         if (this.isReleased) {
             throw new DriverAlreadyReleasedError()
         }
+    }
+
+    private captureInvariantViolated(extra: Record<string, string | boolean>) {
+        const error = new InvariantViolatedError()
+        console.error(
+            "Invariant violated:",
+            Object.keys(extra)
+                .map((key) => `${key}=${extra[key]}`)
+                .join(", "),
+        )
+        console.error(error)
+        captureException(error, { extra })
+    }
+
+    private throwLockTimeoutError(cause: Error) {
+        throw new LockAcquireTimeoutError("SqliteWriteConnectionMutex", {
+            cause,
+        })
     }
 }

--- a/src/error/InvariantViolatedError.ts
+++ b/src/error/InvariantViolatedError.ts
@@ -1,0 +1,11 @@
+import { TypeORMError } from "./TypeORMError"
+
+/** Thrown when an invariant is violated */
+export class InvariantViolatedError extends TypeORMError {
+    constructor(
+        message: string = "Invariant violated",
+        options: ErrorOptions = {},
+    ) {
+        super(message, options)
+    }
+}

--- a/src/error/LockAcquireTimeoutError.ts
+++ b/src/error/LockAcquireTimeoutError.ts
@@ -1,0 +1,11 @@
+import { TypeORMError } from "./TypeORMError"
+
+/** Thrown when acquiring a lock times out */
+export class LockAcquireTimeoutError extends TypeORMError {
+    constructor(lockName: string, options: ErrorOptions = {}) {
+        super(
+            `Timeout waiting for lock ${lockName} to become available`,
+            options,
+        )
+    }
+}

--- a/test/functional/sqlite/entity/Category.ts
+++ b/test/functional/sqlite/entity/Category.ts
@@ -1,0 +1,12 @@
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Column } from "../../../../src/decorator/columns/Column"
+
+@Entity()
+export class Category {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+}

--- a/test/functional/sqlite/entity/Post.ts
+++ b/test/functional/sqlite/entity/Post.ts
@@ -1,0 +1,12 @@
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Column } from "../../../../src/decorator/columns/Column"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    title: string
+}

--- a/test/functional/sqlite/write-connection-timeout.ts
+++ b/test/functional/sqlite/write-connection-timeout.ts
@@ -1,0 +1,82 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { LockAcquireTimeoutError } from "../../../src/error/LockAcquireTimeoutError"
+
+describe("sqlite driver > write connection acquire timeout", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                enabledDrivers: ["sqlite-pooled"],
+                driverSpecific: {
+                    enableWAL: true,
+                    acquireTimeout: 1,
+                },
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should timeout if acquire with trx takes too long", async () => {
+        const connection = connections[0]
+
+        const qr1 = connection.createQueryRunner()
+        const qr2 = connection.createQueryRunner()
+
+        let trx2Threw = null
+        await qr1.startTransaction() // Acquire lock on the connection
+        const trx2Promise = qr2.startTransaction().catch((e) => {
+            trx2Threw = e
+        })
+
+        // Wait for the acquire to timeout
+        await new Promise((resolve) => setTimeout(resolve, 1))
+
+        await trx2Promise
+        expect(trx2Threw).to.be.instanceOf(LockAcquireTimeoutError)
+        expect(qr2.isTransactionActive).to.be.false
+
+        await qr1.query("SELECT 1")
+        await qr1.commitTransaction()
+
+        // Acquiring a lock should now be possible
+        await qr2.startTransaction()
+        await qr2.query("SELECT 1")
+        await qr2.commitTransaction()
+    })
+
+    it("should timeout if acquire without trx takes too long", async () => {
+        const connection = connections[0]
+        const qr1 = connection.createQueryRunner()
+        const qr2 = connection.createQueryRunner()
+
+        let op2Threw = null
+        await qr1.startTransaction() // Acquire lock on the connection
+        const op2Promise = qr2
+            .query("INSERT INTO post (title) VALUES ($1)", ["new post"])
+            .catch((e) => {
+                op2Threw = e
+            })
+
+        // Wait for the acquire to timeout
+        await new Promise((resolve) => setTimeout(resolve, 1))
+
+        await op2Promise
+        expect(op2Threw).to.be.instanceOf(LockAcquireTimeoutError)
+
+        await qr1.query("SELECT 1")
+        await qr1.commitTransaction()
+
+        // Acquiring a lock should now be possible
+        await qr2.startTransaction()
+        await qr2.query("INSERT INTO post (title) VALUES ($1)", ["new post"])
+        await qr2.commitTransaction()
+    })
+})

--- a/test/functional/sqlite/write-connection.ts
+++ b/test/functional/sqlite/write-connection.ts
@@ -1,0 +1,58 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+
+describe("sqlite driver > write connection", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                enabledDrivers: ["sqlite-pooled"],
+                driverSpecific: {
+                    enableWAL: true,
+                },
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should block the second query runner until the first one releases the write connection", async () => {
+        const connection = connections[0]
+        const qr1 = connection.createQueryRunner()
+        const qr2 = connection.createQueryRunner()
+
+        let trx2Started = null
+        await qr1.startTransaction() // Acquire lock on the connection
+        const trx2Promise = qr2.startTransaction().then(() => {
+            trx2Started = Date.now()
+        })
+
+        await new Promise((resolve) => setTimeout(resolve, 100))
+
+        expect(trx2Started).to.be.null
+        await qr1.rollbackTransaction()
+
+        await trx2Promise
+        expect(trx2Started).to.be.not.null
+        await qr2.rollbackTransaction()
+    })
+
+    it("should allow reading even if write lock has been acquired", async () => {
+        const connection = connections[0]
+        const qr1 = connection.createQueryRunner()
+        const qr2 = connection.createQueryRunner()
+
+        await qr1.startTransaction() // Acquire lock on the connection
+
+        await qr2.query("SELECT * FROM post")
+        await qr1.query("SELECT 1")
+
+        await qr1.rollbackTransaction()
+    })
+})


### PR DESCRIPTION
Fix sqlite pooled write connection mutex not being released in case of an error

Also includes:
- Capture exception before invalidating the connection
- Fix typo

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
