### PR TITLE
Consistent migration lifecycle to ensure `beforeMigration` and `afterMigration` are always called

### DIFF
--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -76,8 +76,11 @@ export class MigrationExecutor {
             await this.createMetadataTableIfNotExist(queryRunner)
 
             await queryRunner.beforeMigration()
-            await (migration.instance as any).up(queryRunner)
-            await queryRunner.afterMigration()
+            try {
+                await (migration.instance as any).up(queryRunner)
+            } finally {
+                await queryRunner.afterMigration()
+            }
             await this.insertExecutedMigration(queryRunner, migration)
 
             return migration

--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -439,8 +439,11 @@ export class MigrationExecutor {
         try {
             if (!this.fake) {
                 await queryRunner.beforeMigration()
-                await migrationToRevert.instance!.down(queryRunner)
-                await queryRunner.afterMigration()
+                try {
+                    await migrationToRevert.instance!.down(queryRunner)
+                } finally {
+                    await queryRunner.afterMigration()
+                }
             }
 
             await this.deleteExecutedMigration(queryRunner, migrationToRevert)


### PR DESCRIPTION
https://github.com/typeorm/typeorm/pull/7922 added the code to disable/enable foreign key checks for sqlite when running migrations individually, but is missing the code do so when the migrations are run via connection.runMigrations().
This change ensures a consistent behavior between all the code paths.