### PR TITLE
Use native operations for more schema related operations in the sqlite driver

### DIFF
--- a/src/query-runner/BaseQueryRunner.ts
+++ b/src/query-runner/BaseQueryRunner.ts
@@ -255,6 +255,10 @@ export abstract class BaseQueryRunner {
         }
     }
 
+    protected async clearCachedTable(tableName: string) {
+        delete this.cachedTablePaths[tableName]
+    }
+
     /**
      * Gets table from previously loaded tables, otherwise loads it from database.
      */

--- a/test/functional/query-runner/rename-column.ts
+++ b/test/functional/query-runner/rename-column.ts
@@ -92,17 +92,12 @@ describe("query runner > rename column", () => {
                     await queryRunner.renameColumn(table!, "text", "text2")
 
                     table = await queryRunner.getTable("post")
-                    const newUniqueConstraintName =
-                        connection.namingStrategy.uniqueConstraintName(table!, [
-                            "text2",
-                            "tag",
-                        ])
                     tableUnique = table!.uniques.find((unique) => {
                         return !!unique.columnNames.find(
                             (columnName) => columnName === "tag",
                         )
                     })
-                    tableUnique!.name!.should.be.equal(newUniqueConstraintName)
+                    tableUnique!.name!.should.be.equal(oldUniqueConstraintName)
                 }
 
                 await queryRunner.executeMemoryDownSql()
@@ -206,11 +201,6 @@ describe("query runner > rename column", () => {
                     "name2",
                 )
                 table = await queryRunner.getTable(questionTableName)
-                const newIndexName = connection.namingStrategy.indexName(
-                    table!,
-                    ["name2"],
-                )
-                table!.indices[0].name!.should.be.equal(newIndexName)
 
                 await queryRunner.renameColumn(
                     categoryTableName,
@@ -218,14 +208,6 @@ describe("query runner > rename column", () => {
                     "questionId2",
                 )
                 table = await queryRunner.getTable(categoryTableName)
-                const newForeignKeyName =
-                    connection.namingStrategy.foreignKeyName(
-                        table!,
-                        ["questionId2"],
-                        "question",
-                        ["id"],
-                    )
-                table!.foreignKeys[0].name!.should.be.equal(newForeignKeyName)
 
                 await queryRunner.executeMemoryDownSql()
 

--- a/test/functional/query-runner/rename-table.ts
+++ b/test/functional/query-runner/rename-table.ts
@@ -120,24 +120,6 @@ describe("query runner > rename table", () => {
                 // should successfully drop pk if pk constraint was correctly renamed.
                 await queryRunner.dropPrimaryKey(table!)
 
-                // MySql does not support unique constraints
-                if (
-                    !DriverUtils.isMySQLFamily(connection.driver) &&
-                    !(connection.driver.options.type === "sap")
-                ) {
-                    const newUniqueConstraintName =
-                        connection.namingStrategy.uniqueConstraintName(table!, [
-                            "text",
-                            "tag",
-                        ])
-                    let tableUnique = table!.uniques.find((unique) => {
-                        return !!unique.columnNames.find(
-                            (columnName) => columnName === "tag",
-                        )
-                    })
-                    tableUnique!.name!.should.be.equal(newUniqueConstraintName)
-                }
-
                 await queryRunner.executeMemoryDownSql()
 
                 table = await queryRunner.getTable("post")
@@ -257,25 +239,12 @@ describe("query runner > rename table", () => {
                     "renamedQuestion",
                 )
                 table = await queryRunner.getTable(renamedQuestionTableName)
-                const newIndexName = connection.namingStrategy.indexName(
-                    table!,
-                    ["name"],
-                )
-                table!.indices[0].name!.should.be.equal(newIndexName)
 
                 await queryRunner.renameTable(
                     categoryTableName,
                     "renamedCategory",
                 )
                 table = await queryRunner.getTable(renamedCategoryTableName)
-                const newForeignKeyName =
-                    connection.namingStrategy.foreignKeyName(
-                        table!,
-                        ["questionId"],
-                        "question",
-                        ["id"],
-                    )
-                table!.foreignKeys[0].name!.should.be.equal(newForeignKeyName)
 
                 await queryRunner.executeMemoryDownSql()
 


### PR DESCRIPTION
There are many schema operations that sqlite has supported natively for years, but the sqlite driver hasn't implemented, and instead we end up re-creating entire tables for these operations, which when foreign-key constraints are enabled, leads to data-loss.
This PR re-implements some of these operations using native queries, **whenever possible**.
