### PR TITLE
Add schema undefined fix on top of formatting and test fixes

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -1174,7 +1174,7 @@ export class PostgresDriver implements Driver {
 
         const connection = await this.master.connect()
         const { schema } = this.options
-        if (schema !== "public") {
+        if (schema && schema !== "public") {
             await connection.query(`CREATE SCHEMA IF NOT EXISTS ${schema}`)
             await connection.query(`SET search_path TO ${schema},public`)
         } else {

--- a/test/github-issues/10626/issue-10626.ts
+++ b/test/github-issues/10626/issue-10626.ts
@@ -37,29 +37,7 @@ describe("github issues > #10626 Postgres CREATE INDEX CONCURRENTLY bug", () => 
             }),
         ))
 
-    /*
-     * ISSUE: Test expects PostgreSQL CONCURRENT index dropping to work correctly with proper schema qualification.
-     *
-     * THEORIES FOR FAILURE:
-     * 1. Schema Name Resolution for Concurrent Operations: The test expects "DROP INDEX CONCURRENTLY"
-     *    to use proper schema qualification ("public"."indexName"), but TypeORM may be generating
-     *    SQL with "undefined" schema prefix, causing PostgreSQL to reject the malformed SQL statement.
-     *
-     * 2. Migration Transaction Mode Conflicts: The test sets migrationsTransactionMode to "none" to
-     *    allow CONCURRENT operations (which cannot run in transactions), but other parts of TypeORM
-     *    may still try to wrap the operation in a transaction, causing PostgreSQL to error.
-     *
-     * 3. Index Metadata Schema Context Issues: When working with concurrent index operations, the
-     *    index metadata may not properly inherit or resolve the schema context from the parent table,
-     *    resulting in schema-less index references that PostgreSQL cannot resolve.
-     *
-     * POTENTIAL FIXES:
-     * - Fix schema qualification for concurrent index operations in PostgreSQL driver
-     * - Ensure transaction mode settings are properly respected for concurrent operations
-     * - Improve index metadata schema context inheritance from parent tables
-     */
-    // INFO: checked
-    it.skip("has to drop INDEX CONCURRENTLY", () =>
+    it("has to drop INDEX CONCURRENTLY", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
                 await dataSource.setOptions({
@@ -69,7 +47,7 @@ describe("github issues > #10626 Postgres CREATE INDEX CONCURRENTLY bug", () => 
                 await dataSource.synchronize()
 
                 const queryRunner = dataSource.createQueryRunner()
-                let table = await queryRunner.getTable("user")
+                const table = await queryRunner.getTable("user")
                 if (table) {
                     await queryRunner.dropIndex(table, table?.indices[0])
                 }


### PR DESCRIPTION
## Summary
- Fix for schema creation issue when schema is undefined
- Prevents creation of a schema called `undefined`

## Test plan
- [x] Schema creation logic handles undefined values correctly
- [x] Existing tests continue to pass (with disabled tests skipped)

🤖 Generated with [Claude Code](https://claude.ai/code)