### PR TITLE
chore: Bump version to 0.3.20-18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@n8n/typeorm",
   "private": true,
-  "version": "0.3.20-17",
+  "version": "0.3.20-18",
   "description": "Data-Mapper ORM for TypeScript, ES7, ES6, ES5. Supports PostgreSQL and SQLite databases.",
   "license": "MIT",
   "readmeFilename": "README.md",


### PR DESCRIPTION
### Description of change

Bump version 0.3.20-18


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@n8n/typeorm` to version 0.3.20-18 to prepare the next pre-release. Updates the `package.json` version field only.

<sup>Written for commit e3c27eca19db21f25b9b4c7db75a05606bf35708. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/typeorm/pull/54?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

