### PR TITLE
fix: Use limited depth in QueryPartialEntity

### DIFF
--- a/src/query-builder/QueryPartialEntity.ts
+++ b/src/query-builder/QueryPartialEntity.ts
@@ -7,19 +7,29 @@ export type QueryPartialEntity<T> = {
     [P in keyof T]?: T[P] | (() => string)
 }
 
-/**
- * Make all properties in T optional. Deep version.
- */
+
+type _QueryDeepPartialEntityDecr = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+type _QueryDeepPartialEntity<T, Depth extends number = 10> = [Depth] extends [never]
+    ? T
+    : {
+          [P in keyof T]?:
+              | (T[P] extends Array<infer U>
+                    ? Array<_QueryDeepPartialEntity<U, _QueryDeepPartialEntityDecr[Depth]>>
+                    : T[P] extends ReadonlyArray<infer U>
+                      ? ReadonlyArray<_QueryDeepPartialEntity<U, _QueryDeepPartialEntityDecr[Depth]>>
+                      : _QueryDeepPartialEntity<T[P], _QueryDeepPartialEntityDecr[Depth]>)
+              | (() => string)
+      }
+
+ /**
+  * Make all properties in T optional. Deep version.
+  *
+  * Recursion is bounded by a fixed depth budget instead of a growing `Seen`
+  * union (expensive for the checker) or unbounded recursion (trips the
+  * compiler's own depth limiter with TS2589 on deep payloads such as INode[]).
+  * At the depth floor the full `T` is returned so deep writes stay assignable.
+  */
 export type QueryDeepPartialEntity<T> = _QueryDeepPartialEntity<
     ObjectLiteral extends T ? unknown : T
 >
-
-type _QueryDeepPartialEntity<T> = {
-    [P in keyof T]?:
-        | (T[P] extends Array<infer U>
-              ? Array<_QueryDeepPartialEntity<U>>
-              : T[P] extends ReadonlyArray<infer U>
-                ? ReadonlyArray<_QueryDeepPartialEntity<U>>
-                : _QueryDeepPartialEntity<T[P]>)
-        | (() => string)
-}

--- a/src/query-builder/QueryPartialEntity.ts
+++ b/src/query-builder/QueryPartialEntity.ts
@@ -1,4 +1,4 @@
-import { ObjectLiteral } from "../common/ObjectLiteral"
+import type { ObjectLiteral } from "../common/ObjectLiteral"
 
 /**
  * Make all properties in T optional
@@ -11,18 +11,15 @@ export type QueryPartialEntity<T> = {
  * Make all properties in T optional. Deep version.
  */
 export type QueryDeepPartialEntity<T> = _QueryDeepPartialEntity<
-    ObjectLiteral extends T ? unknown : T,
-    never
->;
+    ObjectLiteral extends T ? unknown : T
+>
 
-type _QueryDeepPartialEntity<Entity, Seen = never> = {
-    [Property in keyof Entity]?: (
-        Entity[Property] extends Seen
-            ? Entity[Property]  // break cycle
-            : Entity[Property] extends Array<infer ArrayItem>
-                ? Array<_QueryDeepPartialEntity<ArrayItem, Seen | Entity[Property]>>
-                : Entity[Property] extends ReadonlyArray<infer ArrayItem>
-                    ? ReadonlyArray<_QueryDeepPartialEntity<ArrayItem, Seen | Entity[Property]>>
-                    : _QueryDeepPartialEntity<Entity[Property], Seen | Entity[Property]>
-    ) | (() => string);
-};
+type _QueryDeepPartialEntity<T> = {
+    [P in keyof T]?:
+        | (T[P] extends Array<infer U>
+              ? Array<_QueryDeepPartialEntity<U>>
+              : T[P] extends ReadonlyArray<infer U>
+                ? ReadonlyArray<_QueryDeepPartialEntity<U>>
+                : _QueryDeepPartialEntity<T[P]>)
+        | (() => string)
+}


### PR DESCRIPTION
### Description of change

QueryPartialEntity type definition was leaky and was causing tsc/tsgo to loop instantiations until it hit the recusion limit of given typechecker. 

Applied the same updated type definition [as applied to the original typeorm repository](https://github.com/typeorm/typeorm/blob/a84b9b3d39c44cc0e5809b4680a5f046bda602cd/src/query-builder/QueryPartialEntity.ts#L13), massively decreasing instantions. ~Claude would've wanted to apply an execution limit to instantiation (to fix TS2589), but I felt that it risked functionality for minimal upside. This change already applies a force multiplier in both tsc, and tsgo.~

Applied the depth budget fix suggested by Claude to resolve the issues the original PR was solving too.

Claude analysis on depth budget:

> Recursion stops at 10 levels and returns the full T. Beyond 10 levels of nesting, a property is no longer treated as a deep-partial and loses the | (() => string) raw-SQL escape at that depth. n8n never nests writes that deep today (hence 0 regressions), so it's theoretical — but if someone ever did, they'd get a confusing assignability error far from the cause. 10 is a tuned magic number, not a principled one.

| version                      | tsgo: TS2589 / inst / time | tsc: errors / inst / time |
|-----------------------------|----------------------------|---------------------------|
| Seen-union (what ships now) | 13 / 77.8M / 27s           | 0 / 11.0M / 18.5s         |
| no-Seen (this one)          | 0 / 5.46M / 1.85s          | 0 / 3.17M / 9.06s         |


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `QueryPartialEntity` and `QueryDeepPartialEntity` with upstream `typeorm` and bounds recursion to prevent runaway type instantiation that slowed builds and caused TS2589 on deep payloads. This speeds up `tsc`/`tsgo` with no runtime impact.

- **Bug Fixes**
  - Added a fixed recursion depth to `QueryDeepPartialEntity` and removed the `Seen` union to avoid checker blowups while keeping deep writes assignable.
  - Switched `ObjectLiteral` to a type-only import.

<sup>Written for commit 80af74342ba242edb0ec28cbe85cc39d9dd5cf31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/typeorm/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

