### PR TITLE
feat: expose connection pool stats

### DIFF
--- a/src/driver/sqlite-pooled/SqliteReadWriteDriver.ts
+++ b/src/driver/sqlite-pooled/SqliteReadWriteDriver.ts
@@ -125,6 +125,15 @@ export class SqliteReadWriteDriver extends AbstractSqliteDriver {
         )
     }
 
+    getPoolStats(): { active: number; idle: number; waiting: number } {
+        const { used, free, pendingAcquires } = this.readonlyPool.getStats()
+        return {
+            active: used,
+            idle: free,
+            waiting: pendingAcquires,
+        }
+    }
+
     normalizeType(column: {
         type?: ColumnType
         length?: number | string

--- a/src/driver/sqlite-pooled/SqliteReadonlyConnectionPool.ts
+++ b/src/driver/sqlite-pooled/SqliteReadonlyConnectionPool.ts
@@ -53,6 +53,18 @@ export class SqliteReadonlyConnectionPool implements SqliteConnectionPool {
         await this.pool.destroy()
     }
 
+    public getStats(): {
+        used: number
+        free: number
+        pendingAcquires: number
+    } {
+        return {
+            used: this.pool.numUsed(),
+            free: this.pool.numFree(),
+            pendingAcquires: this.pool.numPendingAcquires(),
+        }
+    }
+
     public async runExclusive<T>(
         dbLeaseHolder: DbLeaseHolder,
         callback: (leasedDbConnection: DbLease) => Promise<T>,


### PR DESCRIPTION
Let's expose pool stats from the driver so consumers can later observe pool health app-side

PG needs nothing from the fork, `driver.master` is public and `pg.Pool` already has public `totalCount` / `idleCount` / `waitingCount`