### PR TITLE
feat(sqlite-pooled): include write connection in pool stats

### DIFF
--- a/src/driver/sqlite-pooled/SqliteReadWriteDriver.ts
+++ b/src/driver/sqlite-pooled/SqliteReadWriteDriver.ts
@@ -130,7 +130,7 @@ export class SqliteReadWriteDriver extends AbstractSqliteDriver {
         const write = this.writeConnection.getStats()
         return {
             active: read.used + write.active,
-            idle: read.free,
+            idle: read.free + write.idle,
             waiting: read.pendingAcquires + write.waiting,
         }
     }

--- a/src/driver/sqlite-pooled/SqliteReadWriteDriver.ts
+++ b/src/driver/sqlite-pooled/SqliteReadWriteDriver.ts
@@ -126,11 +126,12 @@ export class SqliteReadWriteDriver extends AbstractSqliteDriver {
     }
 
     getPoolStats(): { active: number; idle: number; waiting: number } {
-        const { used, free, pendingAcquires } = this.readonlyPool.getStats()
+        const read = this.readonlyPool.getStats()
+        const write = this.writeConnection.getStats()
         return {
-            active: used,
-            idle: free,
-            waiting: pendingAcquires,
+            active: read.used + write.active,
+            idle: read.free,
+            waiting: read.pendingAcquires + write.waiting,
         }
     }
 

--- a/src/driver/sqlite-pooled/SqliteWriteConnection.ts
+++ b/src/driver/sqlite-pooled/SqliteWriteConnection.ts
@@ -31,6 +31,9 @@ export class SqliteWriteConnection
 
     private dbLease: DbLease | undefined
 
+    /** Callers currently blocked waiting to acquire the write connection. */
+    private waitingWrites = 0
+
     constructor(
         private readonly sqliteLibrary: SqliteLibrary,
         private readonly options: {
@@ -77,14 +80,25 @@ export class SqliteWriteConnection
         }
     }
 
+    public getStats(): { active: number; waiting: number } {
+        return {
+            active: this.writeConnectionMutex.isLocked() ? 1 : 0,
+            waiting: this.waitingWrites,
+        }
+    }
+
     public async runExclusive<T>(
         dbLeaseHolder: DbLeaseHolder,
         callback: (dbLease: DbLease) => Promise<T>,
     ): Promise<T> {
         this.assertNotReleased()
 
+        this.waitingWrites++
+        let acquired = false
         try {
             return await this.writeConnectionMutex.runExclusive(async () => {
+                acquired = true
+                this.waitingWrites--
                 this.dbLease = await this.createAndGetConnection(dbLeaseHolder)
 
                 const result = await callback(this.dbLease).finally(() => {
@@ -109,12 +123,15 @@ export class SqliteWriteConnection
             }
 
             throw error
+        } finally {
+            if (!acquired) this.waitingWrites--
         }
     }
 
     public async leaseConnection(dbLeaseHolder: DbLeaseHolder) {
         this.assertNotReleased()
 
+        this.waitingWrites++
         try {
             await this.writeConnectionMutex.acquire()
         } catch (error) {
@@ -122,6 +139,8 @@ export class SqliteWriteConnection
                 this.throwLockTimeoutError(error)
             }
             throw error
+        } finally {
+            this.waitingWrites--
         }
 
         this.dbLease = await this.createAndGetConnection(dbLeaseHolder)

--- a/src/driver/sqlite-pooled/SqliteWriteConnection.ts
+++ b/src/driver/sqlite-pooled/SqliteWriteConnection.ts
@@ -80,9 +80,11 @@ export class SqliteWriteConnection
         }
     }
 
-    public getStats(): { active: number; waiting: number } {
+    public getStats(): { active: number; idle: number; waiting: number } {
+        const active = this.writeConnectionMutex.isLocked() ? 1 : 0
         return {
-            active: this.writeConnectionMutex.isLocked() ? 1 : 0,
+            active,
+            idle: active ? 0 : 1,
             waiting: this.waitingWrites,
         }
     }


### PR DESCRIPTION
`getPoolStats()` now counts the write connection, not just the readonly pool.

- `active` is reads in use + write busy (0/1)
- `waiting` is read waiters + writers queued

Related: https://github.com/n8n-io/n8n/pull/32670