### PR TITLE
chore: Bump version to 0.3.20-19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@n8n/typeorm",
   "private": true,
-  "version": "0.3.20-18",
+  "version": "0.3.20-19",
   "description": "Data-Mapper ORM for TypeScript, ES7, ES6, ES5. Supports PostgreSQL and SQLite databases.",
   "license": "MIT",
   "readmeFilename": "README.md",


### PR DESCRIPTION

 Bump version to 0.3.20-19

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@n8n/typeorm` version to 0.3.20-19 to prepare the next patch release. No code changes.

<sup>Written for commit 6baca0a361d7fd76b4a59cd051d227c67a2f1af0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/typeorm/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

